### PR TITLE
Enable pdf export for mkdocs

### DIFF
--- a/docs/Developer_Guide.md
+++ b/docs/Developer_Guide.md
@@ -125,8 +125,6 @@ In cases where the version of a JAR file is updated, remove the old JAR
 file and provide path to the removed file when prompted by the wum-uc
 tool .
 
-![](images/icons/grey_arrow_down.png)
-
 **This file will be discontinued when WUM 2.0.0 gets depreciated.**
 
 The update-descriptor.yaml file is used to identify update details by

--- a/docs/Developer_Guide.md
+++ b/docs/Developer_Guide.md
@@ -13,15 +13,14 @@ update directly or convert a patch to an update.
 Before you begin, here are the descriptions of the files used in this
 guide. The wum-uc tool generates both these files.
 
-![](images/icons/grey_arrow_down.png){.expand-control-image}update-descriptor3.yaml
-file
-
-This is a newly introduced file that contains details about the update
-that complies with WUM 3.0.0 . Every update has an
-`         update-descriptor3.yaml       ` file. It has details about the
-products that this update is fully or partially compatible with, the
-file changes (added, removed, or modified), descriptions, and
-instructions.
+>
+!!! Note "Note"
+    This is a newly introduced file that contains details about the update
+    that complies with WUM 3.0.0 . Every update has an
+    `         update-descriptor3.yaml       ` file. It has details about the
+    products that this update is fully or partially compatible with, the
+    file changes (added, removed, or modified), descriptions, and
+    instructions.
 
 A sample file looks like the following:
 
@@ -113,10 +112,10 @@ description: |
 ```
 
 If there are no bug fixes, enter N/A in the `         JIRA_ID       `
-and `         Summary       ` fields. I f there are no instructions,
+and `         Summary       ` fields. If there are no instructions,
 leave a blank line as follows:
 
-![](attachments/103318258/103318263.png){width="150"}
+![](attachments/103318258/103318263.png)
 
 Note that you do not manually modify the `added_files` and
 `             modified_files           ` sections like in the previous
@@ -126,10 +125,9 @@ In cases where the version of a JAR file is updated, remove the old JAR
 file and provide path to the removed file when prompted by the wum-uc
 tool .
 
-![](images/icons/grey_arrow_down.png){.expand-control-image}update-descriptor.yaml
-file
+![](images/icons/grey_arrow_down.png)
 
-**This file will be discontinued when WUM 2.0.0 gets deprecated.**
+**This file will be discontinued when WUM 2.0.0 gets depreciated.**
 
 The update-descriptor.yaml file is used to identify update details by
 WUM 2.0.0. It will get created by the wum-uc tool along with the
@@ -290,8 +288,7 @@ Follow below steps to create an update.
 9.  Note that the update ZIP is created in the location from where you
     execute wum-uc. The tool displays a summary of the update creation.
 
-    ![](images/icons/grey_arrow_down.png){.expand-control-image}Click to
-    see an example...
+    ![](images/icons/grey_arrow_down.png)
 
     Here's an example:
 
@@ -324,22 +321,22 @@ location is
 
 1.  When changing the lifecycle state of the created update from
     Development to Staging, you see a newly added check as follows.
-    Click it.![](attachments/103318258/103318264.png){width="200"}
+    Click it.![](attachments/103318258/103318264.png)
 2.  You get directed to a seperate page as follows: 
 3.  Click **GET UPDATE YAML** to see the YAML information as follows:  
-    ![](attachments/103318258/103318261.png){width="500"}
+    ![](attachments/103318258/103318261.png)
 4.  Verify the YAML information and click **GET PRODUCT LIST** to see
     the product details as follows:  
-    ![](attachments/103318258/103318260.png){width="550"}
+    ![](attachments/103318258/103318260.png)
 5.  Verify the product details and click CONTINUE.
 6.  You get a page as follows. Update it with the products relevant for
     your update number.  
-    ![](attachments/103318258/103318259.png){width="600"}
+    ![](attachments/103318258/103318259.png)
 
 Some samples for the `     UPDATE_LOCATION   ` directory are shown
 below:
-
-![](images/icons/grey_arrow_down.png){.expand-control-image}Sample 1
+>
+!!! Note : "Sample 1"
 
 ``` java
 ├── axis2_1.6.1.wso2v16.jar
@@ -351,7 +348,7 @@ below:
 └── update-descriptor.yaml
 ```
 
-![](images/icons/grey_arrow_down.png){.expand-control-image}Sample 2
+!!! Note : "Sample 2"
 
 ``` java
 ├── LICENSE.txt
@@ -361,7 +358,7 @@ below:
 └── update-descriptor.yaml
 ```
 
-![](images/icons/grey_arrow_down.png){.expand-control-image}Sample 3
+!!! Note : "Sample 3"
 
 ``` java
 ├── LICENSE.txt
@@ -383,7 +380,7 @@ below:
 └── update-descriptor.yaml
 ```
 
-![](images/icons/grey_arrow_down.png){.expand-control-image}Sample 4
+!!! Note : "Sample 4"
 
 ``` java
 ├── bin
@@ -536,9 +533,8 @@ file to new WUM update format when the patch has configuration changes.
     same content above should be added to the instructions field of the
     new `update-descriptor3.yaml` file after successfully creating the
     update.
-
-    ![](images/icons/grey_arrow_down.png){.expand-control-image}Expand
-    to see a sample instructions.txt file...
+>
+    !!!Note : "Expand to see a sample instructions.txt file..."
 
     ``` java
     When the org.wso2.carbon.identity.mgt.IdentityMgtEventListener is enabled via <EventListeners> configuration in repository/conf/identity/identity.xml, it engages CacheClearingUserOperationListener which clears the policy cache.
@@ -571,21 +567,4 @@ file to new WUM update format when the patch has configuration changes.
     created in the current working directory. You can validated it using
     the  `         wum-uc validate        ` command.
 
-## Attachments:
 
-![](images/icons/bullet_blue.gif){width="8" height="8"}
-[overview-products.png](attachments/103318258/103318259.png)
-(image/png)  
-![](images/icons/bullet_blue.gif){width="8" height="8"}
-[Product-details.png](attachments/103318258/103318260.png) (image/png)  
-![](images/icons/bullet_blue.gif){width="8" height="8"}
-[get-updated-YAML.png](attachments/103318258/103318261.png)
-(image/png)  
-![](images/icons/bullet_blue.gif){width="8" height="8"}
-[YAML-description.png](attachments/103318258/103318262.png)
-(image/png)  
-![](images/icons/bullet_blue.gif){width="8" height="8"}
-[blank-line.png](attachments/103318258/103318263.png) (image/png)  
-![](images/icons/bullet_blue.gif){width="8" height="8"}
-[image2018-8-10\_17-37-18.png](attachments/103318258/103318264.png)
-(image/png)  

--- a/docs/Developer_Guide.md
+++ b/docs/Developer_Guide.md
@@ -13,8 +13,7 @@ update directly or convert a patch to an update.
 Before you begin, here are the descriptions of the files used in this
 guide. The wum-uc tool generates both these files.
 
->
-!!! Note "Note"
+!!! note "Note"
     This is a newly introduced file that contains details about the update
     that complies with WUM 3.0.0 . Every update has an
     `         update-descriptor3.yaml       ` file. It has details about the
@@ -76,13 +75,13 @@ In WUM 2.0.0, we used update-descriptor.yaml . The reason to introduce a
 new file in WUM 3.0.0 is because WUM 3.0.0 s upports partial updates.
 For example, in the above sample, the update numbered 2922 gets fully
 applied to `         wso2am-2.1.0.standard       ` product while it gets
-partially applied to `         wso2am-         2.0.0.standard       ` ,
-wso2esb-5.0.0.standard, and `         wso2is-km-5.3.0.standard       `
+partially applied to `         wso2am-2.0.0.standard       ` ,
+`		wso2esb-5.0.0.standard		`, and `         wso2is-km-5.3.0.standard       `
 products.
 
 You should manually fill in the description, instructions, and the
 bug\_fixes fields of the `         update-descriptor3.yaml       ` file
-according to the products listed in it. W hen filling the description
+according to the products listed in it. When filling the description
 and instructions sections of an update that gets fully or partially
 applied to multiple products, use paragraphs to separate the description
 per product. Be careful not to break the initial indentation though as
@@ -286,8 +285,6 @@ Follow below steps to create an update.
 9.  Note that the update ZIP is created in the location from where you
     execute wum-uc. The tool displays a summary of the update creation.
 
-    ![](images/icons/grey_arrow_down.png)
-
     Here's an example:
 
     ``` java
@@ -333,8 +330,7 @@ location is
 
 Some samples for the `     UPDATE_LOCATION   ` directory are shown
 below:
->
-!!! Note : "Sample 1"
+Sample 1
 
 ``` java
 ├── axis2_1.6.1.wso2v16.jar
@@ -346,7 +342,7 @@ below:
 └── update-descriptor.yaml
 ```
 
-!!! Note : "Sample 2"
+Sample 2
 
 ``` java
 ├── LICENSE.txt
@@ -356,7 +352,7 @@ below:
 └── update-descriptor.yaml
 ```
 
-!!! Note : "Sample 3"
+Sample 3
 
 ``` java
 ├── LICENSE.txt
@@ -378,7 +374,7 @@ below:
 └── update-descriptor.yaml
 ```
 
-!!! Note : "Sample 4"
+Sample 4
 
 ``` java
 ├── bin
@@ -502,13 +498,13 @@ WUM update format. 
 
 6.  Follow the update creation process mentioned above to create the
     update.
-7.  Note that, if successful, the  WSO2-CARBON-UPDATE-4.4.0–0237.zip
+7.  Note that, if successful, the  `		WSO2-CARBON-UPDATE-4.4.0–0237.zip		`
      file will be created in the current working directory. You can
     validate it using the  wum-uc validate command.
 
 #### Sample 3: When the patch has config changes
 
-Follow the steps below to convert the WSO2-CARBON-PATCH-4.4.0–0478.zip
+Follow the steps below to convert the `		WSO2-CARBON-PATCH-4.4.0–0478.zip		`
 file to new WUM update format when the patch has configuration changes.
 
 1.  Extract the patch and move the content of the patch0478 directory to
@@ -531,10 +527,9 @@ file to new WUM update format when the patch has configuration changes.
     same content above should be added to the instructions field of the
     new `update-descriptor3.yaml` file after successfully creating the
     update.
->
-    !!!Note : "Expand to see a sample instructions.txt file..."
+     
+??? note "Expand to see a sample instructions.txt file..."
 
-    ``` java
     When the org.wso2.carbon.identity.mgt.IdentityMgtEventListener is enabled via <EventListeners> configuration in repository/conf/identity/identity.xml, it engages CacheClearingUserOperationListener which clears the policy cache.
 
     This should be configurable through <EventListeners> configuration.
@@ -547,7 +542,6 @@ file to new WUM update format when the patch has configuration changes.
     type="org.wso2.carbon.user.core.listener.UserOperationEventListener" name="org.wso2.carbon.identity.entitlement.listener.CacheClearingUserOperationListener" 
     orderId="6" enable="false"
     />
-    ```
 
 3.  Note that the new directory structure looks as follows:
 

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -1,6 +1,5 @@
 
 # Introduction
-
 **WSO2 Updates** include any improvements (e.g., bug fixes, security
 fixes) that are released by WSO2 on top of a released WSO2 product
 version. With updates, you do not have to wait until the next product

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -1,9 +1,4 @@
----
-title: "Introduction"
-date: 2018-11-14T11:59:23+05:30
-draft: false
-weight: 1
----
+
 # Introduction
 
 **WSO2 Updates** include any improvements (e.g., bug fixes, security
@@ -13,17 +8,17 @@ version is released to get the fixes you want. Find out more about WSO2
 updates at <https://wso2.com/updates>.
 
 You can get updates using WSO2 in-place updates or WSO2 update
-manager. The following table shows the key differences of the two:
+manager. The following table shows the key differences between the two:
 
 | WSO2 in-place updates                                                                          | WSO2 update manager (WUM)                                                                                  |
 |------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
-| You can install the in-place updates tool via a WUM update for all the WUM-supported products. | You can download and install the WUM tool from <https://wso2.com/wum/download/>.                           |
+| You can install the in-place updates tool via a WUM update for all the WUM-supported products. | You can download and install the WUM tool from <https://wso2.com/wum/download>.                           |
 | The tool merges the updated configuration files unless there are conflicts.                    | You should manually merge the updated configuration files or use a tool like Puppet.                       |
 | The tool handles backup and restore.                                                           | You should store backups with the custom configurations in your system, in case you have to restore later. |
 | Supported on only Unix-based (e.g., Linux, OS X) operating systems.                            | Supported on all operating systems.                                                                        |
 
 A subscription is mandatory to get WSO2 updates. A subscription can be
-one of the following types:
+of one of the following types:
 
 -   Free Trial Subscription: Provides all the functionality of a paid
     subscription for 14 days. The validity period can be extended.
@@ -31,10 +26,8 @@ one of the following types:
 -   Paid Subscription: Can discuss your specific requirements with a
     WSO2 accounts manager and set up a subscription via a channel.Here
     are the available channels:
-
-<!-- -->
-
--   -   **Full**: This is the default channel. It gives all updates
+ 
+     -   **Full**: This is the default channel. It gives all updates
         including bug fixes, security fixes, and improvements.
 
     -   **Security**: Gives security bug fixes only.

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -19,6 +19,8 @@ manager. The following table shows the key differences between the two:
 A subscription is mandatory to get WSO2 updates. A subscription can be
 of one of the following types:
 
+{! index.md !}
+
 -   Free Trial Subscription: Provides all the functionality of a paid
     subscription for 14 days. The validity period can be extended.
 

--- a/docs/Using_WSO2_In-Place_Updates.md
+++ b/docs/Using_WSO2_In-Place_Updates.md
@@ -50,8 +50,8 @@ Let's begin.
         subscription.
 4.  Note that the tool starts to update your product.
 
-    ![](images/icons/grey_arrow_down.png){.expand-control-image}If the
-    tool lists any conflicts, click to see how to resolve them...
+    ??? note "If the
+    tool lists any conflicts, see how to resolve them..."
 
     A conflict is likely to happen when a configuration file or artifact
     that you have customized has changed in the updates. If the
@@ -67,10 +67,10 @@ Let's begin.
         3.  The file that is in the new update level, after updating
             (e.g., `test.jag.updated`).
         4.  The difference of the two files
-            in **ii** and **iii **(e.g., `test.jag.diff`).
+            in **ii** and **iii**(e.g., `test.jag.diff`).
     2.  By looking at the three files (`.old`, `.updated`, and `.diff`),
         resolve the conflicts and save the resolved file with
-        the **`.final` **extension (e.g., `test.jag.final`). 
+        the **`.final`**extension (e.g., `test.jag.final`). 
     3.  Run the tool again with the '--continue' flag for the tool to
         merge the changes in `.final` file with the file which created
         the conflict.
@@ -95,7 +95,8 @@ Let's begin.
     ./update_darwin --revert (On OS X)
     ```
 
-    **Tip**: To see a list of commands the tool provides, run the tool
-    with the **--help** option.
+    !!! note **"Tip"**: 
+    To see a list of commands the tool provides, run the tool with 
+    the **--help** option.
 
 You have now updated your product using the WSO2 in-place update tool.

--- a/docs/Using_WSO2_In-Place_Updates.md
+++ b/docs/Using_WSO2_In-Place_Updates.md
@@ -1,13 +1,12 @@
 
 # Using WSO2 In-Place Updates
-
 The **WSO2 in-place updates** tool allows you to update your currently
 used product by fetching updates from the server and merging all
 configurations and files. The tool also gives backup and restore
 capability.
 
 Given below is how to get in-place updates to your product.
->
+
 !!! note "Before you begin"
         -   Make sure you are already using a [WSO2
             product](https://wso2.com/platform). (Let's call this

--- a/docs/Using_WSO2_In-Place_Updates.md
+++ b/docs/Using_WSO2_In-Place_Updates.md
@@ -49,8 +49,7 @@ Let's begin.
         subscription.
 4.  Note that the tool starts to update your product.
 
-    ??? note "If the
-    tool lists any conflicts, see how to resolve them..."
+!!! note "If the tool lists any conflicts, see how to resolve them..."
 
     A conflict is likely to happen when a configuration file or artifact
     that you have customized has changed in the updates. If the
@@ -58,18 +57,18 @@ Let's begin.
     In case you have customized .war or .car files, you need to apply
     the customizations on top of the updated .war and .car files.
 
-    1.  Go to the locations of the files that have conflicts and note
-        the following files that are created by the tool:  
-        1.  The file that has your customizations (e.g., `test.jag`).
-        2.  The file that was there in the previous update level, before
-            updating (e.g., `test.jag.old`).
-        3.  The file that is in the new update level, after updating
-            (e.g., `test.jag.updated`).
-        4.  The difference of the two files
+	1.  Go to the locations of the files that have conflicts and note
+    the following files that are created by the tool:  
+    	1.  The file that has your customizations (e.g., `test.jag`).
+    	2.  The file that was there in the previous update level, before
+        updating (e.g., `test.jag.old`).
+    	3.  The file that is in the new update level, after updating
+        (e.g., `test.jag.updated`).
+    	4.  The difference of the two files
             in **ii** and **iii**(e.g., `test.jag.diff`).
     2.  By looking at the three files (`.old`, `.updated`, and `.diff`),
         resolve the conflicts and save the resolved file with
-        the **`.final`**extension (e.g., `test.jag.final`). 
+        the `.final` extension (e.g., `test.jag.final`). 
     3.  Run the tool again with the '--continue' flag for the tool to
         merge the changes in `.final` file with the file which created
         the conflict.
@@ -84,17 +83,17 @@ Let's begin.
         your custom configurations and deleted all the other temporary
         files (i.e., `.old`, `.updated`, `.diff`, and `.final`)
 
+
 5.  Restart the server.
 
 6.  If you want to revert the updates and restore the previous state,
     run the following command:
-
     ``` java
     ./update_linux --revert (On Linux)
     ./update_darwin --revert (On OS X)
-    ```
+    ```    
 
-    !!! note **"Tip"**: 
+!!! note "Tip" 
     To see a list of commands the tool provides, run the tool with 
     the **--help** option.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ extra:
    
 plugins:
    - search
+   - pdf-export
 
 extra_css: [extra.css]
 


### PR DESCRIPTION
## Purpose
To incorporate a plugin that enables pdf export of mkdoc files.

## Goals
To assure that exporting documents is feasible on migrating to Git. 

## Security checks
* Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
* Ran FindSecurityBugs plugin and verified report? n/a
* Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes